### PR TITLE
use bitnami/git instead of *-snapshot-*

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,7 @@ RUN wget https://github.com/mikefarah/yq/releases/download/3.3.2/yq_linux_amd64 
     chmod +x yq_linux_amd64 && \
     mv yq_linux_amd64 /usr/local/bin/yq
 
-# Use our minideb image that is lower than chart-testing and has a bash interpreter
-FROM bitnami/minideb:buster-snapshot-20200708T204754Z
-
-RUN install_packages git
+FROM bitnami/git:2.27.0-debian-10-r38
 
 COPY --from=builder /usr/local/bin/yq /usr/local/bin/yq
 COPY --from=builder /usr/local/bin/ct /usr/local/bin/ct


### PR DESCRIPTION
We were having problems when using `bitnami/minideb:buster-snapshot-*`

```bash
Step 1/9 : FROM quay.io/helmpack/chart-testing:v2.4.1 AS builder
 ---> bca09207f0c7
Step 2/9 : RUN wget https://github.com/mikefarah/yq/releases/download/3.3.2/yq_linux_amd64 &&     chmod +x yq_linux_amd64 &&     mv yq_linux_amd64 /usr/local/bin/yq
 ---> Using cache
 ---> 4d614f8b08c0
Step 3/9 : FROM bitnami/minideb:buster-snapshot-20200708T204754Z
 ---> 73f8ab0af303
Step 4/9 : RUN install_packages git
 ---> Running in 83b70615e0f2
E: Release file for http://snapshot.debian.org/archive/debian-security/20200708T204754Z/dists/buster/updates/InRelease is expired (invalid since 19h 3min 0s). Updates for this repository will not be applied.
apt failed, retrying
E: Release file for http://snapshot.debian.org/archive/debian-security/20200708T204754Z/dists/buster/updates/InRelease is expired (invalid since 19h 3min 3s). Updates for this repository will not be applied.
apt failed, retrying
E: Release file for http://snapshot.debian.org/archive/debian-security/20200708T204754Z/dists/buster/updates/InRelease is expired (invalid since 19h 3min 4s). Updates for this repository will not be applied.
The command '/bin/sh -c install_packages git' returned a non-zero code: 100

##[warning]Docker build failed with exit code 100, back off 1.27 seconds before retry.
```

So we decided to change it to `bitnami/git:<tag>` instead